### PR TITLE
update-cache: Build the cache without loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Finally, use `zplug install` to install your plugins and reload `.zshrc`.
 | `status`  | Check if the remote repositories are up to date | `--select` |
 | `clean`   | Remove repositories which are no longer managed | `--force`,`--select` |
 | `clear`   | Remove the cache file | (None) |
+| `update-cache` | Update zplug's cache files (Note: `load` does this automatically) | `--verbose` |
 | `info`    | Show the information such as the source URL and tag values for the given package | (None) |
 
 #### Take a closer look

--- a/autoload/commands/__update-cache__
+++ b/autoload/commands/__update-cache__
@@ -1,0 +1,72 @@
+#!/usr/bin/env zsh
+# Description:
+#   Update zplug's cache files (Note: `load` does this automatically)
+
+__zplug::core::load::prepare
+
+local    repo arg
+local -a repos
+local -A tags
+
+repos=( "${(k)zplugs[@]}" )
+
+while (( $# > 0 ))
+do
+    arg="$1"
+    case "$arg" in
+        --verbose)
+            zstyle ':zplug:core:load' 'verbose' yes
+            ;;
+        -*|--*)
+            __zplug::core::options::unknown "$arg"
+            return $status
+            ;;
+        "")
+            # Invalid
+            return 1
+            ;;
+        */*)
+            repos+=( "${arg:gs:@::}" )
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    shift
+done
+
+# Check if cache is up-to-date
+if __zplug::core::cache::diff; then
+    return $status
+fi
+
+for repo in "${repos[@]}"
+do
+    # Generate cache for each as:type in parallel
+    {
+        tags[as]="$(__zplug::core::core::run_interfaces 'as' "$repo")"
+
+        case "$tags[as]" in
+            "plugin")
+                __zplug::core::cache::plugins "$repo"
+                ;;
+            "command")
+                __zplug::core::cache::commands "$repo"
+                ;;
+            "theme")
+                __zplug::core::cache::themes "$repo"
+                ;;
+            *)
+                __zplug::io::print::f \
+                    --die \
+                    --zplug \
+                    --func \
+                    "as tag is invalid value (%s)\n" \
+                    "$fg[green]$repo$reset_color"
+                ;;
+        esac
+    } &
+done
+wait
+
+return $status

--- a/autoload/zplug
+++ b/autoload/zplug
@@ -7,7 +7,7 @@ case "$arg" in
         __zplug::core::options::parse "$argv[@]"
         ;;
 
-    check | install | update | list | clean | status | clear | load | info)
+    check | install | update | list | clean | status | clear | update-cache | load | info)
         shift
         __zplug::core::core::run_interfaces \
             "$arg" \


### PR DESCRIPTION
Exposing this functionality enables developers to build on zplug's capabilities. They can build their own loading logic while using zplug to manage and download plugins. In a proof of concept, I was able to shave a few hundred milliseconds off my startup time this way.